### PR TITLE
Add admin user management tab

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -137,3 +137,15 @@ button:disabled {
   width: 100%;
   resize: vertical;
 }
+
+/* Gestión de usuarios */
+.admin-users .user-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.admin-users .users-table th,
+.admin-users .users-table td {
+  padding: 0.25rem 0.5rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,7 @@ import AuditLogs         from "./components/AuditLogs";
 import UploadDocument    from "./components/UploadDocument";
 import SearchDocuments   from "./components/SearchDocuments";
 import DocumentsList     from "./components/DocumentsList";
+import ManageUsers       from "./components/ManageUsers";
 
 import "./App.css";
 
@@ -72,6 +73,14 @@ export default function App() {
             element={
               <PrivateRoute requireAdmin>
                 <AuditLogs />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/users"
+            element={
+              <PrivateRoute requireAdmin>
+                <ManageUsers />
               </PrivateRoute>
             }
           />

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -143,6 +143,9 @@ export default function Dashboard() {
               <button onClick={() => navigate("/audit")} className="test-button">
                 Registros de auditoría
               </button>
+              <button onClick={() => navigate("/users")} className="test-button">
+                Gestión de usuarios
+              </button>
             </div>
           )}
         </div>

--- a/frontend/src/components/ManageUsers.jsx
+++ b/frontend/src/components/ManageUsers.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from "react";
+import { authAPI } from "../services/api";
+
+export default function ManageUsers() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [form, setForm] = useState({ email: "", password: "", display_name: "", is_admin: false });
+
+  const loadUsers = async () => {
+    try {
+      const { data } = await authAPI.listUsers();
+      setUsers(data);
+    } catch (err) {
+      setError(err.response?.data?.detail || err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadUsers(); }, []);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((f) => ({ ...f, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      await authAPI.adminCreateUser(form);
+      setForm({ email: "", password: "", display_name: "", is_admin: false });
+      loadUsers();
+    } catch (err) {
+      alert(err.response?.data?.detail || err.message);
+    }
+  };
+
+  const toggleAdmin = async (uid, isAdmin) => {
+    try {
+      await authAPI.updateUser(uid, { role: isAdmin ? "user" : "admin" });
+      loadUsers();
+    } catch (err) {
+      alert(err.response?.data?.detail || err.message);
+    }
+  };
+
+  const handleDelete = async (uid) => {
+    if (!confirm("¿Eliminar usuario?")) return;
+    try {
+      await authAPI.deleteUser(uid);
+      loadUsers();
+    } catch (err) {
+      alert(err.response?.data?.detail || err.message);
+    }
+  };
+
+  if (loading) return <p>Cargando…</p>;
+  if (error) return <div className="error">{error}</div>;
+
+  return (
+    <div className="page admin-users">
+      <h2>Gestión de usuarios</h2>
+
+      <form onSubmit={handleCreate} className="user-form">
+        <input name="email" value={form.email} onChange={handleChange} placeholder="Correo" required />
+        <input name="password" type="password" value={form.password} onChange={handleChange} placeholder="Contraseña" required />
+        <input name="display_name" value={form.display_name} onChange={handleChange} placeholder="Nombre" />
+        <label>
+          <input type="checkbox" name="is_admin" checked={form.is_admin} onChange={handleChange} /> Admin
+        </label>
+        <button type="submit">Crear usuario</button>
+      </form>
+
+      <table className="users-table">
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Nombre</th>
+            <th>Rol</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.uid}>
+              <td>{u.email}</td>
+              <td>{u.display_name || ""}</td>
+              <td>{u.custom_claims?.admin ? "Admin" : "Usuario"}</td>
+              <td>
+                <button onClick={() => toggleAdmin(u.uid, u.custom_claims?.admin)}>
+                  {u.custom_claims?.admin ? "Quitar admin" : "Hacer admin"}
+                </button>
+                <button onClick={() => handleDelete(u.uid)}>Eliminar</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -211,8 +211,32 @@ export const authAPI = {
    * 
    * @returns {Promise<Object>} Respuesta de verificación
    */
-  testAdminRoute: () => 
-    api.get("/auth/admin-only-test")
+  testAdminRoute: () =>
+    api.get("/auth/admin-only-test"),
+
+  /**
+   * Lista usuarios (solo admin)
+   */
+  listUsers: (limit = 100) =>
+    api.get(`/auth/users?limit=${limit}`),
+
+  /**
+   * Crea un usuario desde el panel de administración
+   */
+  adminCreateUser: (data) =>
+    api.post("/auth/users", data),
+
+  /**
+   * Actualiza datos de un usuario
+   */
+  updateUser: (uid, data) =>
+    api.patch(`/auth/users/${uid}`, data),
+
+  /**
+   * Elimina un usuario
+   */
+  deleteUser: (uid) =>
+    api.delete(`/auth/users/${uid}`)
 };
 
 // ===== API DE DOCUMENTOS =====


### PR DESCRIPTION
## Summary
- add Firebase user CRUD in backend
- expose new auth routes for admins
- extend API client with user admin functions
- add React component for user management
- update dashboard navigation and routes
- style user admin page

## Testing
- `python -m py_compile backend/services/auth_service.py backend/routes/auth_routes.py`
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68609d80c4588332b9af01a87a383493